### PR TITLE
Remove the password prompt from provisioning

### DIFF
--- a/droplet.go
+++ b/droplet.go
@@ -45,8 +45,6 @@ func CreateDroplet(config *Config) (int, error) {
 
 	ipAddr := WaitForDroplet(ctx, client, newDroplet.ID)
 
-	ConnectToHost(ipAddr)
-
 	return newDroplet.ID, nil
 }
 

--- a/main.go
+++ b/main.go
@@ -63,10 +63,11 @@ func main() {
 		},
 		Action: func(c *cli.Context) error {
 			fmt.Println("Provisioning Digital Ocean Droplet...")
-			digitalOceanId, _ := CreateDroplet(&config)
+			digitalOceanId, ipAddr, _ := CreateDroplet(&config)
 
 			fmt.Println("Your droplet as been created")
 			fmt.Println("DigitalOcean ID: ", digitalOceanId)
+			fmt.Println("IP Address: ", ipAddr)
 			return nil
 		},
 	}


### PR DESCRIPTION
This removes the password prompt by deleting the function `ConnectToHost`. This function was originally intended for making use of ssh to provision the droplet, this was before cloud init was introduced. 

closes #8 