### PR TITLE
Add bootstrap password cli flag

### DIFF
--- a/cloud-config-tmp
+++ b/cloud-config-tmp
@@ -21,5 +21,5 @@ runcmd:
   - "git clone --branch <REPO_BRANCH> <REPO_URL> /run/dashboard"
   - "cd /run/dashboard"
   - "docker build -f /run/dockerfiles/Dockerfile -t <REPO_BRANCH> ."
-  - "docker run -d --restart unless-stopped --privileged -p 80:80 -p 443:443 -e CATTLE_UI_DASHBOARD_INDEX=https://localhost/dashboard/index.html -e CATTLE_UI_OFFLINE_PREFERRED=true <REPO_BRANCH>"
+  - "docker run -d --restart unless-stopped --privileged -p 80:80 -p 443:443 -e CATTLE_UI_DASHBOARD_INDEX=https://localhost/dashboard/index.html -e CATTLE_UI_OFFLINE_PREFERRED=true CATTLE_BOOTSTRAP_PASSWORD=<RANCHER_BOOTSTRAP_PASSWORD> <REPO_BRANCH>"
   - "echo $(date) ': Time to do the stuff'"

--- a/cloud.go
+++ b/cloud.go
@@ -18,6 +18,7 @@ func UpdateConfig(fileString string, config *Config) {
 	f = strings.Replace(f, "<REPO_BRANCH>", config.branch, -1)
 	f = strings.Replace(f, "<REPO_URL>", config.url, 1)
 	f = strings.Replace(f, "<RANCHER_VERSION>", config.rancherVersion, 1)
+	f = strings.Replace(f, "<RANCHER_BOOTSTRAP_PASSWORD>", config.bootstrapPassword, 1)
 
 	data := []byte(f)
 	_ = ioutil.WriteFile("./cloud-config", data, 0o600)

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/docker/docker-credential-helpers v0.6.4 // indirect
 	github.com/golang/protobuf v1.3.5 // indirect
 	github.com/google/go-querystring v1.0.0 // indirect
+	github.com/google/uuid v1.3.0 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/urfave/cli/v2 v2.5.0 // indirect
 	golang.org/x/net v0.0.0-20200324143707-d3edc9973b7e // indirect

--- a/go.sum
+++ b/go.sum
@@ -13,6 +13,8 @@ github.com/golang/protobuf v1.3.5 h1:F768QJ1E9tib+q5Sc8MkdJi1RxLTbRcTf8LJV56aRls
 github.com/golang/protobuf v1.3.5/go.mod h1:6O5/vntMXwX2lRkT1hjjk0nAC1IDOTvTlVgjlRvqsdk=
 github.com/google/go-querystring v1.0.0 h1:Xkwi/a1rcvNg1PPYe5vI8GbeBY/jrVuDX5ASuANWTrk=
 github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
+github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
+github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf35Ld67mk=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=

--- a/main.go
+++ b/main.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"os"
 
+	"github.com/google/uuid"
 	"github.com/urfave/cli/v2"
 )
 
@@ -64,7 +65,7 @@ func main() {
 			&cli.StringFlag{
 				Name:        "bootstrap-password",
 				Usage:       "Bootstrap password for Rancher",
-				Required:    true,
+				Value:       uuid.New().String(),
 				Destination: &config.bootstrapPassword,
 			},
 		},
@@ -75,6 +76,7 @@ func main() {
 			fmt.Println("Your droplet as been created")
 			fmt.Println("DigitalOcean ID: ", digitalOceanId)
 			fmt.Println("IP Address: ", ipAddr)
+			fmt.Println("Bootstrap Password: ", config.bootstrapPassword)
 			return nil
 		},
 	}

--- a/main.go
+++ b/main.go
@@ -9,12 +9,13 @@ import (
 )
 
 type Config struct {
-	dropletName    string
-	accessToken    string
-	sshFingerprint string
-	url            string
-	branch         string
-	rancherVersion string
+	dropletName       string
+	accessToken       string
+	sshFingerprint    string
+	url               string
+	branch            string
+	rancherVersion    string
+	bootstrapPassword string
 }
 
 func main() {
@@ -59,6 +60,12 @@ func main() {
 				Usage:       "Target version of Rancher",
 				DefaultText: "v2.6-head",
 				Destination: &config.rancherVersion,
+			},
+			&cli.StringFlag{
+				Name:        "bootstrap-password",
+				Usage:       "Bootstrap password for Rancher",
+				Required:    true,
+				Destination: &config.bootstrapPassword,
 			},
 		},
 		Action: func(c *cli.Context) error {


### PR DESCRIPTION
This adds a bootstrap password for provisioning a new rancher instance so that users won't need to ssh into the digital ocean droplet on first run.

closes #6 